### PR TITLE
Add MCP infinity agentic loop module

### DIFF
--- a/mcp-microservice/README.md
+++ b/mcp-microservice/README.md
@@ -16,3 +16,13 @@ source venv/bin/activate
 pip install -r requirements.txt
 uvicorn src.main:app --reload --port 8015
 ```
+
+## Infinity Agentic Loop
+
+Im Verzeichnis `src/infinity` befindet sich ein Skript, das mehrere Agenten in Wellen startet und die Ergebnisse als Textdateien speichert. Es kann separat genutzt werden, um kreative Iterationen zu erzeugen.
+
+Aufrufbeispiel:
+
+```bash
+python -m infinity.loop src/infinity/specs/sample_spec.yaml
+```

--- a/mcp-microservice/src/infinity/README.md
+++ b/mcp-microservice/src/infinity/README.md
@@ -1,0 +1,25 @@
+# MCP Infinity Agentic Loop
+
+Dieses Modul erweitert den MCP-Microservice um ein einfaches Agenten-Loop-Skript.
+Es liest eine YAML-Spezifikation ein und startet mehrere parallele Aufrufe an das
+hinterlegte LLM. Die Antworten werden je Welle in Textdateien gespeichert.
+
+## Beispielaufruf
+
+```bash
+python -m infinity.loop specs/sample_spec.yaml
+```
+
+## Spezifikationsformat
+
+```yaml
+prompt: "Entwerfe ein neues UI-Konzept f\u00fcr das Modul Lagerverwaltung."
+model: "gpt-3.5-turbo"
+max_tokens: 300
+parallel_agents: 2
+count: 3
+output_dir: "agent_outputs"
+```
+
+Damit werden drei Wellen mit jeweils zwei parallelen Agenten ausgef\u00fchrt. Die
+Antworten landen in `agent_outputs/wave_<nummer>_agent_<index>.txt`.

--- a/mcp-microservice/src/infinity/loop.py
+++ b/mcp-microservice/src/infinity/loop.py
@@ -1,0 +1,63 @@
+import asyncio
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import openai
+import yaml
+
+
+async def _call_openai(prompt: str, model: str, max_tokens: int) -> str:
+    """Call OpenAI asynchronously and return the response text."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+    openai.api_key = api_key
+    resp = await openai.ChatCompletion.acreate(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=max_tokens,
+    )
+    return resp.choices[0].message["content"]
+
+
+async def _run_wave(prompt: str, model: str, max_tokens: int, wave: int, parallel: int, out_dir: Path) -> None:
+    """Run one wave of parallel agent calls."""
+    tasks = []
+    for i in range(parallel):
+        tasks.append(_call_openai(prompt, model, max_tokens))
+    results = await asyncio.gather(*tasks)
+    for i, text in enumerate(results):
+        outfile = out_dir / f"wave_{wave}_agent_{i}.txt"
+        outfile.write_text(text)
+
+
+async def run_infinite(spec: Dict[str, Any]) -> None:
+    """Execute waves of agents based on the spec configuration."""
+    prompt = spec["prompt"]
+    model = spec.get("model", "gpt-3.5-turbo")
+    max_tokens = spec.get("max_tokens", 200)
+    parallel = spec.get("parallel_agents", 1)
+    count = spec.get("count", 1)
+    out_dir = Path(spec.get("output_dir", "agent_outputs"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for wave in range(count):
+        await _run_wave(prompt, model, max_tokens, wave, parallel, out_dir)
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run MCP infinity agentic loop")
+    parser.add_argument("spec_file", help="Path to YAML specification file")
+    args = parser.parse_args()
+
+    with open(args.spec_file, "r", encoding="utf-8") as f:
+        spec = yaml.safe_load(f)
+
+    asyncio.run(run_infinite(spec))
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-microservice/src/infinity/specs/sample_spec.yaml
+++ b/mcp-microservice/src/infinity/specs/sample_spec.yaml
@@ -1,0 +1,6 @@
+prompt: "Entwerfe ein neues Dashboard f\u00fcr das NeuroERP."
+model: "gpt-3.5-turbo"
+max_tokens: 150
+parallel_agents: 2
+count: 1
+output_dir: "agent_outputs"


### PR DESCRIPTION
## Summary
- add `infinity` package to `mcp-microservice` with example spec and README
- describe new script in main README

## Testing
- `pip install -r backend/requirements.txt`
- `pip install requests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6857a002fc60832c9ee6615440e9b11f